### PR TITLE
Implement GZIP compression/decompression on all GRPC connections

### DIFF
--- a/core/dialing.go
+++ b/core/dialing.go
@@ -20,6 +20,7 @@ import (
 	"github.com/cloudflare/cfssl/log"
 	"google.golang.org/grpc"
 	"google.golang.org/grpc/credentials"
+	"google.golang.org/grpc/encoding/gzip"
 )
 
 // type TransportCredentials interface {
@@ -185,7 +186,7 @@ func (t *Terminus) dialPeer(address string, namespace string) (*grpc.ClientConn,
 		t:         t,
 		namespace: namespace,
 	}
-	return grpc.Dial(address, grpc.WithTransportCredentials(tc), grpc.FailOnNonTempDialError(true), grpc.WithBlock(), grpc.WithTimeout(30*time.Second))
+	return grpc.Dial(address, grpc.WithTransportCredentials(tc), grpc.FailOnNonTempDialError(true), grpc.WithBlock(), grpc.WithTimeout(30*time.Second), grpc.WithDefaultCallOptions(grpc.UseCompressor(gzip.Name)))
 }
 
 func (t *Terminus) ServerTransportCredentials() credentials.TransportCredentials {

--- a/server/local.go
+++ b/server/local.go
@@ -15,6 +15,7 @@ import (
 	"github.com/pborman/uuid"
 	"github.com/prometheus/client_golang/prometheus"
 	"google.golang.org/grpc"
+	_ "google.golang.org/grpc/encoding/gzip"
 )
 
 var lg = logging.MustGetLogger("main")

--- a/server/peering.go
+++ b/server/peering.go
@@ -11,6 +11,8 @@ import (
 	pb "github.com/immesys/wavemq/mqpb"
 	"github.com/prometheus/client_golang/prometheus"
 	"google.golang.org/grpc"
+	"google.golang.org/grpc/encoding"
+	_ "google.golang.org/grpc/encoding/gzip"
 )
 
 //Some instrumentation
@@ -34,6 +36,8 @@ func init() {
 	prometheus.MustRegister(pmFailedQuery)
 	prometheus.MustRegister(pmFailedSubscribe)
 	prometheus.MustRegister(pmFailedPublish)
+
+	encoding.RegisterCompressor(encoding.GetCompressor("gzip"))
 }
 
 type peerServer struct {


### PR DESCRIPTION
Using the "new" compression API (https://github.com/grpc/grpc-go/blob/master/Documentation/compression.md).
When remote server does not have GZIP enabled, we get an error; may want to re-dial without GZIP in that case.

Question: when server does not implement GZIP, do we re-dial without the GZIP option? I'm currently using `grpc.WithDefaultCallOptions` to apply GZIP compression on all outgoing calls, but the used options could be configured during the connection to the remote GRPC server instead.