### PR TITLE
Return NoProofFound when hitting cache in FormSubRequest

### DIFF
--- a/core/security.go
+++ b/core/security.go
@@ -786,6 +786,9 @@ func (am *AuthModule) FormSubRequest(p *pb.SubscribeParams, routerID string) (*p
 				expiry = time.Unix(0, p.AbsoluteExpiry)
 			}
 		} else {
+			if !cachedproof.Valid {
+				return nil, wve.Err(wve.NoProofFound, "we've cached that there is no proof for this")
+			}
 			proofder = cachedproof.DER
 			expiry = cachedproof.ProofExpiry
 			if p.AbsoluteExpiry != 0 && expiry.After(time.Unix(0, p.AbsoluteExpiry)) {


### PR DESCRIPTION
The method forgot to check if the proof was valid when retrieving it
from the cache. If it is *not* valid, then we return the NoProofFound
error like in FormQueryRequest.

This caused a situation where if a client attempted to re-subscribe
after first failing to subscribe due to a lack of a proof, the client
would successfully get the server to allocate subscription resources,
even though the upstream connection wasn't set